### PR TITLE
Add drawer demo page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import ProgressDemoPage from './pages/ProgressDemo';
 import SelectDemoPage from './pages/SelectDemo';
 import TablePlaygroundPage from './pages/TableDemo';
 import ListDemoPage from './pages/ListDemoPage';
+import DrawerDemoPage from './pages/DrawerDemo';
 
 export function App() {
   const { setTheme, theme } = useTheme();
@@ -67,6 +68,7 @@ export function App() {
       <Route path="/select-demo" element={<SelectDemoPage />} />
       <Route path="/table-demo" element={<TablePlaygroundPage />} />
       <Route path="/list-demo" element={<ListDemoPage />} />
+      <Route path="/drawer-demo" element={<DrawerDemoPage />} />
     </Routes>
   );
 }

--- a/src/pages/DrawerDemo.tsx
+++ b/src/pages/DrawerDemo.tsx
@@ -1,0 +1,89 @@
+// src/pages/DrawerDemo.tsx
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  Drawer,
+  useTheme,
+} from '@archway/valet';
+
+export default function DrawerDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+
+  const [leftOpen, setLeftOpen] = useState(false);
+  const [rightOpen, setRightOpen] = useState(false);
+  const [stubbornOpen, setStubbornOpen] = useState(false);
+
+  return (
+    <Surface>
+      <Stack
+        spacing="lg"
+        style={{ padding: theme.spacing['lg'], maxWidth: 980, margin: '0 auto' }}
+      >
+        <Typography variant="h2" bold>
+          Drawer Showcase
+        </Typography>
+        <Typography variant="subtitle">
+          Minimal slide-in navigation panel
+        </Typography>
+
+        {/* 1. Basic uncontrolled drawer */}
+        <Typography variant="h3">1. Left drawer</Typography>
+        <Button onClick={() => setLeftOpen(true)}>Open left drawer</Button>
+        <Drawer open={leftOpen} onClose={() => setLeftOpen(false)}>
+          <Stack spacing="md" style={{ padding: theme.spacing['md'] }}>
+            <Typography variant="h4" bold>
+              Left Drawer
+            </Typography>
+            <Typography>Click outside or press ESC to close.</Typography>
+          </Stack>
+        </Drawer>
+
+        {/* 2. Controlled right drawer */}
+        <Typography variant="h3">2. Controlled right drawer</Typography>
+        <Stack direction="row" spacing="md">
+          <Button onClick={() => setRightOpen(true)}>Open</Button>
+          <Button onClick={() => setRightOpen(false)}>Close</Button>
+        </Stack>
+        <Drawer anchor="right" open={rightOpen} onClose={() => setRightOpen(false)}>
+          <Stack spacing="md" style={{ padding: theme.spacing['md'] }}>
+            <Typography variant="h4" bold>
+              Controlled Drawer
+            </Typography>
+            <Typography>State managed by external buttons.</Typography>
+          </Stack>
+        </Drawer>
+
+        {/* 3. Non-dismissable bottom drawer */}
+        <Typography variant="h3">3. Disable backdrop & ESC</Typography>
+        <Button onClick={() => setStubbornOpen(true)}>Open stubborn drawer</Button>
+        <Drawer
+          anchor="bottom"
+          open={stubbornOpen}
+          onClose={() => setStubbornOpen(false)}
+          disableBackdropClick
+          disableEscapeKeyDown
+        >
+          <Stack spacing="md" style={{ padding: theme.spacing['md'] }}>
+            <Typography variant="h4" bold>
+              Can't close via backdrop or ESC
+            </Typography>
+            <Button onClick={() => setStubbornOpen(false)}>Close</Button>
+          </Stack>
+        </Drawer>
+
+        {/* Theme toggle + back nav */}
+        <Stack direction="row" spacing="lg">
+          <Button variant="outlined" onClick={toggleMode}>
+            Toggle light / dark
+          </Button>
+          <Button onClick={() => navigate(-1)}>← Back</Button>
+        </Stack>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -103,6 +103,15 @@ export default function MainPage() {
 
               <Button
                 size="lg"
+                onClick={() => navigate('/drawer-demo')}
+              >
+                <Typography>
+                  Drawer
+                </Typography>
+              </Button>
+
+              <Button
+                size="lg"
                 onClick={() => navigate('/panel-demo')}
               >
                 <Typography>


### PR DESCRIPTION
## Summary
- add DrawerDemo page to showcase Drawer component
- add route and navigation link to new demo

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build`
- `npm run dev` (manual check, server started at http://localhost:5173/)

------
https://chatgpt.com/codex/tasks/task_e_6853da7d3de083209d1530041453f1f2