### PR TITLE
Add demos for new Valet components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,12 @@ import SelectDemoPage from './pages/SelectDemo';
 import TablePlaygroundPage from './pages/TableDemo';
 import ListDemoPage from './pages/ListDemoPage';
 import DrawerDemoPage from './pages/DrawerDemo';
+import AppBarDemoPage from './pages/AppBarDemo';
+import BreadcrumbsDemoPage from './pages/BreadcrumbsDemo';
+import GridDemoPage from './pages/GridDemo';
+import PaginationDemoPage from './pages/PaginationDemo';
+import SpeedDialDemoPage from './pages/SpeedDialDemo';
+import StepperDemoPage from './pages/StepperDemo';
 
 export function App() {
   const { setTheme, theme } = useTheme();
@@ -69,6 +75,12 @@ export function App() {
       <Route path="/table-demo" element={<TablePlaygroundPage />} />
       <Route path="/list-demo" element={<ListDemoPage />} />
       <Route path="/drawer-demo" element={<DrawerDemoPage />} />
+      <Route path="/appbar-demo" element={<AppBarDemoPage />} />
+      <Route path="/breadcrumbs-demo" element={<BreadcrumbsDemoPage />} />
+      <Route path="/grid-demo" element={<GridDemoPage />} />
+      <Route path="/pagination-demo" element={<PaginationDemoPage />} />
+      <Route path="/speeddial-demo" element={<SpeedDialDemoPage />} />
+      <Route path="/stepper-demo" element={<StepperDemoPage />} />
     </Routes>
   );
 }

--- a/src/pages/AppBarDemo.tsx
+++ b/src/pages/AppBarDemo.tsx
@@ -1,0 +1,50 @@
+// src/pages/AppBarDemo.tsx
+import { Surface, Stack, Typography, Button, AppBar, Box, useTheme } from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+
+export default function AppBarDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+
+  return (
+    <Surface>
+      <Stack
+        spacing="lg"
+        style={{ padding: theme.spacing['lg'], maxWidth: 980, margin: '0 auto' }}
+      >
+        <Typography variant="h2" bold>
+          AppBar Showcase
+        </Typography>
+        <Typography variant="subtitle">
+          Basic usage and positioning
+        </Typography>
+
+        <Typography variant="h3">1. Static bar</Typography>
+        <AppBar>
+          <Typography variant="h4">Static</Typography>
+        </AppBar>
+
+        <Typography variant="h3">2. Fixed bar</Typography>
+        <AppBar position="fixed" background={theme.colors['secondary'] as string} textColor={theme.colors['secondaryText'] as string}>
+          <Typography variant="h4">Fixed</Typography>
+        </AppBar>
+        <Box style={{ height: 100 }}></Box>
+
+        <Typography variant="h3">3. Sticky bar</Typography>
+        <Box style={{ height: 200 }}>
+          <AppBar position="sticky" style={{ top: theme.spacing['md'] }}>
+            <Typography variant="h4">Sticky</Typography>
+          </AppBar>
+          <Box style={{ height: 300 }}></Box>
+        </Box>
+
+        <Stack direction="row" spacing="lg">
+          <Button variant="outlined" onClick={toggleMode}>
+            Toggle light / dark
+          </Button>
+          <Button onClick={() => navigate(-1)}>← Back</Button>
+        </Stack>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/pages/BreadcrumbsDemo.tsx
+++ b/src/pages/BreadcrumbsDemo.tsx
@@ -1,0 +1,39 @@
+// src/pages/BreadcrumbsDemo.tsx
+import { Surface, Stack, Typography, Button, Breadcrumbs, useTheme } from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+
+export default function BreadcrumbsDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+
+  const items = [
+    { label: 'Home', href: '#' },
+    { label: 'Library', href: '#' },
+    { label: 'Data' },
+  ];
+
+  return (
+    <Surface>
+      <Stack
+        spacing="lg"
+        style={{ padding: theme.spacing['lg'], maxWidth: 980, margin: '0 auto' }}
+      >
+        <Typography variant="h2" bold>Breadcrumbs Showcase</Typography>
+        <Typography variant="subtitle">Navigation trail examples</Typography>
+
+        <Typography variant="h3">1. Default separator</Typography>
+        <Breadcrumbs items={items} />
+
+        <Typography variant="h3">2. Custom separator</Typography>
+        <Breadcrumbs items={items} separator="›" />
+
+        <Stack direction="row" spacing="lg">
+          <Button variant="outlined" onClick={toggleMode}>
+            Toggle light / dark
+          </Button>
+          <Button onClick={() => navigate(-1)}>← Back</Button>
+        </Stack>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/pages/GridDemo.tsx
+++ b/src/pages/GridDemo.tsx
@@ -1,0 +1,38 @@
+// src/pages/GridDemo.tsx
+import { Surface, Stack, Typography, Button, Grid, Box, useTheme } from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+
+export default function GridDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+
+  return (
+    <Surface>
+      <Stack
+        spacing="lg"
+        style={{ padding: theme.spacing['lg'], maxWidth: 980, margin: '0 auto' }}
+      >
+        <Typography variant="h2" bold>Grid Showcase</Typography>
+        <Typography variant="subtitle">Responsive column layout</Typography>
+
+        <Typography variant="h3">1. Two columns</Typography>
+        <Grid columns={2} gap="md">
+          <Box style={{ background: theme.colors['primary'] as string, color: theme.colors['primaryText'] as string, padding: theme.spacing['md'] }}>A</Box>
+          <Box style={{ background: theme.colors['secondary'] as string, color: theme.colors['secondaryText'] as string, padding: theme.spacing['md'] }}>B</Box>
+        </Grid>
+
+        <Typography variant="h3">2. Four columns</Typography>
+        <Grid columns={4} gap="sm">
+          {['1','2','3','4'].map(n => (
+            <Box key={n} style={{ background: theme.colors['primary'] as string, color: theme.colors['primaryText'] as string, padding: theme.spacing['sm'], textAlign: 'center' }}>{n}</Box>
+          ))}
+        </Grid>
+
+        <Stack direction="row" spacing="lg">
+          <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
+          <Button onClick={() => navigate(-1)}>← Back</Button>
+        </Stack>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -190,6 +190,60 @@ export default function MainPage() {
                   Typography
                 </Typography>
               </Button>
+
+              <Button
+                size="lg"
+                onClick={() => navigate('/appbar-demo')}
+              >
+                <Typography>
+                  AppBar
+                </Typography>
+              </Button>
+
+              <Button
+                size="lg"
+                onClick={() => navigate('/breadcrumbs-demo')}
+              >
+                <Typography>
+                  Breadcrumbs
+                </Typography>
+              </Button>
+
+              <Button
+                size="lg"
+                onClick={() => navigate('/grid-demo')}
+              >
+                <Typography>
+                  Grid
+                </Typography>
+              </Button>
+
+              <Button
+                size="lg"
+                onClick={() => navigate('/pagination-demo')}
+              >
+                <Typography>
+                  Pagination
+                </Typography>
+              </Button>
+
+              <Button
+                size="lg"
+                onClick={() => navigate('/speeddial-demo')}
+              >
+                <Typography>
+                  Speed Dial
+                </Typography>
+              </Button>
+
+              <Button
+                size="lg"
+                onClick={() => navigate('/stepper-demo')}
+              >
+                <Typography>
+                  Stepper
+                </Typography>
+              </Button>
             </Stack>
           </Panel>
 

--- a/src/pages/PaginationDemo.tsx
+++ b/src/pages/PaginationDemo.tsx
@@ -1,0 +1,30 @@
+// src/pages/PaginationDemo.tsx
+import { useState } from 'react';
+import { Surface, Stack, Typography, Button, Pagination, useTheme } from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+
+export default function PaginationDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+
+  return (
+    <Surface>
+      <Stack
+        spacing="lg"
+        style={{ padding: theme.spacing['lg'], maxWidth: 980, margin: '0 auto' }}
+      >
+        <Typography variant="h2" bold>Pagination Showcase</Typography>
+        <Typography variant="subtitle">Controlled page selection</Typography>
+
+        <Pagination count={5} page={page} onChange={setPage} />
+        <Typography variant="body">Current page: {page}</Typography>
+
+        <Stack direction="row" spacing="lg">
+          <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
+          <Button onClick={() => navigate(-1)}>← Back</Button>
+        </Stack>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/pages/SpeedDialDemo.tsx
+++ b/src/pages/SpeedDialDemo.tsx
@@ -1,0 +1,35 @@
+// src/pages/SpeedDialDemo.tsx
+import { Surface, Stack, Typography, Button, SpeedDial, Icon, useTheme } from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+
+export default function SpeedDialDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+
+  const actions = [
+    { icon: <Icon icon="mdi:content-copy" />, label: 'Copy', onClick: () => alert('Copy') },
+    { icon: <Icon icon="mdi:share-variant" />, label: 'Share', onClick: () => alert('Share') },
+    { icon: <Icon icon="mdi:delete" />, label: 'Delete', onClick: () => alert('Delete') },
+  ];
+
+  return (
+    <Surface>
+      <Stack
+        spacing="lg"
+        style={{ padding: theme.spacing['lg'], maxWidth: 980, margin: '0 auto' }}
+      >
+        <Typography variant="h2" bold>SpeedDial Showcase</Typography>
+        <Typography variant="subtitle">Floating action button</Typography>
+
+        <Typography variant="h3">Example</Typography>
+        <Typography variant="body">Click the fab to reveal actions.</Typography>
+        <SpeedDial icon={<Icon icon="mdi:plus" />} actions={actions} />
+
+        <Stack direction="row" spacing="lg">
+          <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
+          <Button onClick={() => navigate(-1)}>← Back</Button>
+        </Stack>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/pages/StepperDemo.tsx
+++ b/src/pages/StepperDemo.tsx
@@ -1,0 +1,35 @@
+// src/pages/StepperDemo.tsx
+import { useState } from 'react';
+import { Surface, Stack, Typography, Button, Stepper, useTheme } from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+
+export default function StepperDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+  const [active, setActive] = useState(0);
+
+  const steps = ['First', 'Second', 'Third'];
+
+  return (
+    <Surface>
+      <Stack
+        spacing="lg"
+        style={{ padding: theme.spacing['lg'], maxWidth: 980, margin: '0 auto' }}
+      >
+        <Typography variant="h2" bold>Stepper Showcase</Typography>
+        <Typography variant="subtitle">Simple progress indicator</Typography>
+
+        <Stepper steps={steps} active={active} />
+        <Stack direction="row" spacing="md">
+          <Button onClick={() => setActive((a) => Math.max(0, a - 1))}>Back</Button>
+          <Button onClick={() => setActive((a) => Math.min(steps.length - 1, a + 1))}>Next</Button>
+        </Stack>
+
+        <Stack direction="row" spacing="lg">
+          <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
+          <Button onClick={() => navigate(-1)}>← Back</Button>
+        </Stack>
+      </Stack>
+    </Surface>
+  );
+}


### PR DESCRIPTION
## Summary
- clone valet repo for reference
- demo new components: AppBar, Breadcrumbs, Grid, Pagination, SpeedDial and Stepper
- wire new pages into the router and homepage
- resolve Valet path via built dist
- revert tsconfig and Vite alias changes

## Testing
- `npm run build` *(fails: Module '@archway/valet' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853dfa5ac90832088bfc88aca28305b